### PR TITLE
Proof of concept for GUI testing with JGiven and Arquillian

### DIFF
--- a/GUITESTING.adoc
+++ b/GUITESTING.adoc
@@ -1,0 +1,62 @@
+= GUI Testing
+
+The `impl` modules includes GUI tests based on http://arquillian.org/modules/graphene-extension/[Arquillian's Graphene] and http://jgiven.org/[JGiven]. 
+
+It tries to facilitated best practices from Behaviour Driven Development (BDD) and Page Object Patterns.
+JGiven produces a nice (static) HTML5 output that gives an overview of the tests implemented.
+
+See `impl/src/test/java/org/dukecon/server/gui` for examples.
+
+== FAQ
+
+What do I write into the PageTest classes?::
+
+Please place BDD style code here following the Given/When/Then pattern.
+
+What do I write into the Stage classes?::
+
+These implement the methods called in the PageTest classes.
+They interact on a business level with the web pages.
+They must not access the elements of the web page directly.
+
+What do I write into the Page classes?::
+
+Each Page class wraps a GUI screen. When a screen changes its layout or design (HTML tags, but same logic), you'll need to change only your Page class.
+All your tests will stay the same.
+
+What do I the Tag annotations for?::
+
+Use these annotations to group your tests.
+You'll find them in the output.
+
+How do I run the tests from my IDE?::
+
+You can run and debug them from your IDE like any other test.
++
+Prerequisite: Please run a selenium server locally first.
+You'll find a script inside this project's selenium folder.
+Firefox needs to be installed on your local machine.
+Have a look at arquillian.xml to re-configure this default.
+
+How do I run the tests in the automatic build?::
+
+Maven will run Surefire as part of the build.
+Arquillian will ensure that PhantomJS, a headless browser is available on the build machine.
+
+Where do I find the automatic test reports?::
+
+After you have run 
++
+[source]
+----
+mvn test
+mvn jgiven:report
+----
++
+you'll find them in `impl/target/jgiven-reports/html`
+
+Where can I find out more about the tools used?::
+
+* JGiven: http://jgiven.org/
+* Arquillian: http://arquillian.org/
+* Arquillian Graphene: http://arquillian.org/modules/graphene-extension/

--- a/impl/.gitignore
+++ b/impl/.gitignore
@@ -1,0 +1,2 @@
+/phantomjsdriver.log
+/jgiven-reports

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -23,10 +23,37 @@
         <spock.version>1.0-groovy-2.4</spock.version>
         
         <surefire.argline></surefire.argline>
+		<jgiven.version>0.9.5</jgiven.version>
     </properties>
 
+	<dependencyManagement>
     <dependencies>
         <dependency>
+				<groupId>org.jboss.arquillian</groupId>
+				<artifactId>arquillian-bom</artifactId>
+				<version>1.1.5.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.arquillian.extension</groupId>
+				<artifactId>arquillian-drone-bom</artifactId>
+				<version>1.3.1.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.arquillian.selenium</groupId>
+				<artifactId>selenium-bom</artifactId>
+				<version>2.48.2</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
             <groupId>org.dukecon</groupId>
             <artifactId>dukecon-server-api</artifactId>
             <version>${project.version}</version>
@@ -110,6 +137,42 @@
             <version>1.1.0-SNAPSHOT</version>
             <type>swf</type>
         </dependency-->
+		<dependency>
+			<groupId>org.jboss.arquillian.graphene</groupId>
+			<artifactId>graphene-webdriver</artifactId>
+			<version>2.0.3.Final</version>
+			<type>pom</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.arquillian.junit</groupId>
+			<artifactId>arquillian-junit-standalone</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.arquillian.extension</groupId>
+			<artifactId>arquillian-phantom-binary</artifactId>
+			<version>1.9.7</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>xml-apis</groupId>
+			<artifactId>xml-apis</artifactId>
+			<version>1.4.01</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.tngtech.jgiven</groupId>
+			<artifactId>jgiven-junit</artifactId>
+			<version>${jgiven.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.1.0</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <profiles>
@@ -165,17 +228,57 @@
                 <version>2.9.2-01</version>
                 <extensions>true</extensions>
             </plugin>
+			<!-- copy the html5 war file to the target folder so surefire can pick it up -->
             <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.dukecon</groupId>
+									<artifactId>dukecon-html5-client</artifactId>
+									<type>war</type>
+									<overWrite>true</overWrite>
+								</artifactItem>
+							</artifactItems>
+							<stripVersion>true</stripVersion>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>${surefire.argline}</argLine>
                     <useFile>false</useFile>
+					<additionalClasspathElements>
+						<!-- this is necessary so Spring boot picks up the static content in /public that is used by the GUI test -->
+						<additionalClasspathElement>${project.build.directory}/dependency/dukecon-html5-client.war</additionalClasspathElement>
+					</additionalClasspathElements>
                     <includes>
                         <include>**/*Spec.java</include>
                         <include>**/*Spec.groovy</include>
                         <include>**/*Test*.java</include>
                         <include>**/*Test*.groovy</include>
                     </includes>
+					<systemProperties>
+						<!-- when you run the tests in the IDE, arquillian.xml is used
+						with a firefox browser served by a remote selenium. -->
+						<!-- when you run the tests from maven, use the arquillian-headless.xml
+						instead that uses a phantom headless browser -->
+						<property>
+							<name>arquillian.xml</name>
+							<value>arquillian-headless.xml</value>
+						</property>
+					</systemProperties>
                 </configuration>
             </plugin>
             <!--
@@ -202,6 +305,22 @@
                 <artifactId>flyway-maven-plugin</artifactId>
                 <version>3.2.1</version>
             </plugin>
+			<plugin>
+				<groupId>com.tngtech.jgiven</groupId>
+				<artifactId>jgiven-maven-plugin
+				</artifactId>
+				<version>${jgiven.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<format>html5</format>
+				</configuration>
+			</plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/impl/src/selenium/.gitignore
+++ b/impl/src/selenium/.gitignore
@@ -1,0 +1,2 @@
+/IEDriverServer.exe
+/selenium-server-standalone-*.jar

--- a/impl/src/selenium/README-selenium.md
+++ b/impl/src/selenium/README-selenium.md
@@ -1,0 +1,18 @@
+# Running Selenium
+
+## Idea
+
+Using this standalone Selenium Remote Driver it is a lot easier to update it to the latest version. It will also enable you to configure your local environment (instead of keeping this information within your project).
+
+## Running
+
+In order to run Selenium, download the latest Selenium driver from 
+
+[http://docs.seleniumhq.org/download/](http://docs.seleniumhq.org/download/)
+
+and place it in this folder.
+
+You can then start a standalone remote Selenium driver using the `selenium.bat` batch file 
+you find in this folder.
+
+The current setup will pick up your locally installed browsers (i.e. Firefox) automatically without further configuration.

--- a/impl/src/selenium/selenium.bat
+++ b/impl/src/selenium/selenium.bat
@@ -1,0 +1,2 @@
+for %%i in (*.jar) do set SELENIUM=%%i
+java -Dwebdriver.ie.driver=IEDriverServer.exe -jar %SELENIUM%

--- a/impl/src/test/java/org/dukecon/server/gui/AbstractPageTest.java
+++ b/impl/src/test/java/org/dukecon/server/gui/AbstractPageTest.java
@@ -1,0 +1,50 @@
+package org.dukecon.server.gui;
+
+import com.tngtech.jgiven.junit.ScenarioTest;
+import org.dukecon.server.util.arquillian.ContextRule;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.junit.ArquillianClassRule;
+import org.jboss.arquillian.junit.ArquillianRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.openqa.selenium.WebDriver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.embedded.EmbeddedWebApplicationContext;
+
+import java.net.URL;
+
+/**
+ * Base class for all Selenium/Graphene webpage tests.
+ */
+public class AbstractPageTest<GIVEN, WHEN, THEN> extends ScenarioTest<GIVEN, WHEN, THEN> {
+
+    @ClassRule
+    public static ArquillianClassRule classRule = new ArquillianClassRule();
+
+    @Value("${local.server.port}")
+    int port;
+
+    /**
+     * Althogh this is not used within this class, it is needed to trigger the
+     * Arquillian's Graphene initialization.
+     */
+    @Drone
+    public WebDriver browser;
+
+    @Autowired
+    private EmbeddedWebApplicationContext server;
+
+    /**
+     * Inject the URL to Arquillian so @Location annotations work as expected.
+     * Needs to be placed before the ArquillianRule.
+     */
+    @Rule
+    public ContextRule contextRule = new ContextRule(
+            () -> new URL("http://localhost:"
+            + port + server.getServletContext().getContextPath() + "/"));
+
+    @Rule
+    public ArquillianRule arquillianRule = new ArquillianRule();
+
+}

--- a/impl/src/test/java/org/dukecon/server/gui/DetailPageTest.java
+++ b/impl/src/test/java/org/dukecon/server/gui/DetailPageTest.java
@@ -1,0 +1,28 @@
+package org.dukecon.server.gui;
+
+import org.dukecon.DukeConServerApplication;
+import org.dukecon.server.gui.stage.GivenStartPage;
+import org.dukecon.server.gui.stage.ThenDetailPage;
+import org.dukecon.server.gui.stage.WhenStartPage;
+import org.dukecon.server.gui.tag.DetailPageTag;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = DukeConServerApplication.class)
+@WebIntegrationTest({"server.port=8080", "management.port=0"})
+public class DetailPageTest extends AbstractPageTest<GivenStartPage, WhenStartPage, ThenDetailPage> {
+
+    @Test
+    @DetailPageTag
+    public void should_show_details_page() throws InterruptedException {
+        given().start_page_opened_in_browser();
+        when().click_on_first_talk();
+        then().talk_details_are_visible()
+                .and().talk_abstract_is_visible();
+    }
+
+}

--- a/impl/src/test/java/org/dukecon/server/gui/StartPageTest.java
+++ b/impl/src/test/java/org/dukecon/server/gui/StartPageTest.java
@@ -1,0 +1,27 @@
+package org.dukecon.server.gui;
+
+import org.dukecon.DukeConServerApplication;
+import org.dukecon.server.gui.stage.GivenStartPage;
+import org.dukecon.server.gui.stage.ThenStartPage;
+import org.dukecon.server.gui.stage.WhenStartPage;
+import org.dukecon.server.gui.tag.StartPageTag;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = DukeConServerApplication.class)
+@WebIntegrationTest({"server.port=8080", "management.port=0"})
+public class StartPageTest extends AbstractPageTest<GivenStartPage, WhenStartPage, ThenStartPage> {
+
+    @Test
+    @StartPageTag
+    public void should_show_start_page() throws InterruptedException {
+        given().start_page_opened_in_browser();
+        then().$1_days_should_be_shown(2)
+                .and().all_filters_should_have_at_least_$1_values(2);
+    }
+
+}

--- a/impl/src/test/java/org/dukecon/server/gui/package-info.java
+++ b/impl/src/test/java/org/dukecon/server/gui/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * This includes the GUI tests written based on Arquillian's Graphene and JGiven. It tries to
+ * facilitated best practices from Behaviour Driven Development (BDD) and Page Object Patterns.
+ * <p />
+ * Read more about it the GUITESTING.adoc
+ */
+package org.dukecon.server.gui;

--- a/impl/src/test/java/org/dukecon/server/gui/page/AbstractPage.java
+++ b/impl/src/test/java/org/dukecon/server/gui/page/AbstractPage.java
@@ -1,0 +1,25 @@
+package org.dukecon.server.gui.page;
+
+import com.tngtech.jgiven.attachment.Attachment;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Base class for all pages. Provides common functionality like screenshots.
+ */
+public abstract class AbstractPage {
+
+    @Drone
+    private WebDriver browser;
+
+    public Attachment createScreenshot() {
+        byte[] screenshot = ((TakesScreenshot) browser).getScreenshotAs(OutputType.BYTES);
+        return Attachment
+                .fromBinaryBytes(screenshot, com.tngtech.jgiven.attachment.MediaType.PNG)
+                .withTitle("screenshot " + this.getClass().getSimpleName()
+                        + " (" + browser.getCurrentUrl() + ")");
+    }
+
+}

--- a/impl/src/test/java/org/dukecon/server/gui/page/DetailsPage.java
+++ b/impl/src/test/java/org/dukecon/server/gui/page/DetailsPage.java
@@ -1,0 +1,31 @@
+package org.dukecon.server.gui.page;
+
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.Graphene;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+public class DetailsPage extends AbstractPage {
+
+    @Drone
+    private WebDriver browser;
+
+    @FindBy(css = ".talk-details")
+    private WebElement talkDetails;
+
+    @FindBy(css = ".talk-abstract")
+    private WebElement talkAbstract;
+
+    public void verify() {
+        Graphene.waitModel().until().element(talkDetails).is().visible();
+    }
+
+    public void detailsAreVisible() {
+        talkDetails.isDisplayed();
+    }
+
+    public void abstractIsVisible() {
+        talkAbstract.isDisplayed();
+    }
+}

--- a/impl/src/test/java/org/dukecon/server/gui/page/StartPage.java
+++ b/impl/src/test/java/org/dukecon/server/gui/page/StartPage.java
@@ -1,0 +1,98 @@
+package org.dukecon.server.gui.page;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.Graphene;
+import org.jboss.arquillian.graphene.page.Location;
+import org.openqa.selenium.*;
+import org.openqa.selenium.support.FindBy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Location("")
+public class StartPage extends AbstractPage {
+
+    @Drone
+    private WebDriver browser;
+
+    @FindBy(css = "#days_filter .selected")
+    private WebElement selectedDay;
+
+    @FindBy(css = "#days_filter")
+    private WebElement daysFilter;
+
+    @FindBy(css = ".talk-cell div")
+    private List<WebElement> talks;
+
+    public void verify() {
+        browser.manage().window().setSize(new Dimension(1024, 800));
+        /* clear local storage, otherwise the app will not work in PhantomJS (but it will
+         work in other browsers like Firefox.
+         TODO: find out why and fix in the app
+          */
+        ((JavascriptExecutor) browser).executeScript("localStorage.clear()");
+        browser.navigate().refresh();
+        Graphene.waitModel().withTimeout(10, TimeUnit.SECONDS).until().element(selectedDay).is().present();
+    }
+
+    public DetailsPage clickOnFirstTalk() {
+        assertThat(talks.size()).describedAs("size of talks").isGreaterThanOrEqualTo(1);
+        talks.get(0).findElement(By.cssSelector("a")).click();
+        DetailsPage detailsPage = Graphene.createPageFragment(DetailsPage.class, browser.findElement(By.cssSelector("body")));
+        detailsPage.verify();
+        return detailsPage;
+    }
+
+    /**
+     * Typed access to the days listed to filter the talks.
+     */
+    public List<Day> getDays() {
+        return daysFilter.findElements(By.tagName("button")).stream()
+                .map(e -> new Day(e.getText())).collect(Collectors.toList());
+    }
+
+    /**
+     * Typed access to all the filters on the left.
+     */
+    public Map<Filter, List<FilterItem>> getFilters() {
+        Map<Filter, List<FilterItem>> result = new HashMap<>();
+        List<WebElement> values = browser.findElements(By.cssSelector(".filter-box .filter-values"));
+        List<WebElement> labels = browser.findElements(By.cssSelector(".filter-box .filter-category"));
+        assertThat(values).hasSameSizeAs(labels);
+        for (int i = 0; i < values.size(); ++i) {
+            result.put(new Filter(labels.get(i).getText()),
+                    values.get(i).findElements(By.cssSelector("label")).stream()
+                            .map(e -> new FilterItem(e.getText())).collect(Collectors.toList()));
+        }
+        return result;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @ToString
+    public static class Day {
+        private String day;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @ToString
+    public static class Filter {
+        private String filter;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @ToString
+    public static class FilterItem {
+        private String filterItem;
+    }
+}

--- a/impl/src/test/java/org/dukecon/server/gui/stage/AbstractStage.java
+++ b/impl/src/test/java/org/dukecon/server/gui/stage/AbstractStage.java
@@ -1,0 +1,23 @@
+package org.dukecon.server.gui.stage;
+
+import com.tngtech.jgiven.CurrentStep;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.IntroWord;
+import org.dukecon.server.gui.page.AbstractPage;
+
+/**
+ * Base class for all stages. Provides common elements like screenshots and intro words.
+ */
+public abstract class AbstractStage<SELF extends AbstractStage<?>> {
+    @ExpectedScenarioState
+    private CurrentStep currentStep;
+
+    protected void screenShot(AbstractPage page) {
+        currentStep.addAttachment(page.createScreenshot());
+    }
+
+    @IntroWord
+    public SELF and() {
+        return (SELF) this;
+    }
+}

--- a/impl/src/test/java/org/dukecon/server/gui/stage/GivenStartPage.java
+++ b/impl/src/test/java/org/dukecon/server/gui/stage/GivenStartPage.java
@@ -1,0 +1,23 @@
+package org.dukecon.server.gui.stage;
+
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import org.dukecon.server.gui.page.StartPage;
+import org.jboss.arquillian.graphene.Graphene;
+
+public class GivenStartPage extends AbstractStage<GivenStartPage> {
+
+    @ProvidedScenarioState
+    private StartPage startPage;
+
+    public GivenStartPage start_page_opened_in_browser() {
+        try {
+            startPage = Graphene.goTo(StartPage.class);
+            startPage.verify();
+            return this;
+        } finally {
+            screenShot(startPage);
+        }
+    }
+
+
+}

--- a/impl/src/test/java/org/dukecon/server/gui/stage/ThenDetailPage.java
+++ b/impl/src/test/java/org/dukecon/server/gui/stage/ThenDetailPage.java
@@ -1,0 +1,20 @@
+package org.dukecon.server.gui.stage;
+
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import org.dukecon.server.gui.page.DetailsPage;
+
+public class ThenDetailPage extends AbstractStage<ThenDetailPage> {
+
+    @ProvidedScenarioState
+    DetailsPage page;
+
+    public ThenDetailPage talk_details_are_visible() {
+        page.detailsAreVisible();
+        return this;
+    }
+
+    public ThenDetailPage talk_abstract_is_visible() {
+        page.abstractIsVisible();
+        return this;
+    }
+}

--- a/impl/src/test/java/org/dukecon/server/gui/stage/ThenStartPage.java
+++ b/impl/src/test/java/org/dukecon/server/gui/stage/ThenStartPage.java
@@ -1,0 +1,31 @@
+package org.dukecon.server.gui.stage;
+
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import org.dukecon.server.gui.page.StartPage;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThenStartPage extends AbstractStage<ThenStartPage> {
+
+    @ExpectedScenarioState
+    private StartPage startPage;
+
+    public ThenStartPage $1_days_should_be_shown(int size) {
+        assertThat(startPage.getDays()).hasSize(size);
+        return this;
+    }
+
+    public ThenStartPage $1_levels_should_be_shown(int size) {
+        return this;
+    }
+
+    public void all_filters_should_have_at_least_$1_values(int minSize) {
+        for (Map.Entry<StartPage.Filter, List<StartPage.FilterItem>> e : startPage.getFilters().entrySet()) {
+            assertThat(e.getValue().size()).describedAs("size of filter '%s'", e.getKey())
+                    .isGreaterThanOrEqualTo(minSize);
+        }
+    }
+}

--- a/impl/src/test/java/org/dukecon/server/gui/stage/WhenStartPage.java
+++ b/impl/src/test/java/org/dukecon/server/gui/stage/WhenStartPage.java
@@ -1,0 +1,23 @@
+package org.dukecon.server.gui.stage;
+
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import org.dukecon.server.gui.page.DetailsPage;
+import org.dukecon.server.gui.page.StartPage;
+
+public class WhenStartPage extends AbstractStage<WhenStartPage> {
+
+    @ExpectedScenarioState
+    StartPage startPage;
+
+    @ProvidedScenarioState
+    DetailsPage detailPage;
+
+    public void click_on_first_talk() {
+        try {
+            detailPage = startPage.clickOnFirstTalk();
+        } finally {
+            screenShot(detailPage != null ? detailPage : startPage);
+        }
+    }
+}

--- a/impl/src/test/java/org/dukecon/server/gui/tag/DetailPageTag.java
+++ b/impl/src/test/java/org/dukecon/server/gui/tag/DetailPageTag.java
@@ -1,0 +1,11 @@
+package org.dukecon.server.gui.tag;
+
+import com.tngtech.jgiven.annotation.IsTag;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@IsTag(name = "Page: Detail")
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DetailPageTag {
+}

--- a/impl/src/test/java/org/dukecon/server/gui/tag/StartPageTag.java
+++ b/impl/src/test/java/org/dukecon/server/gui/tag/StartPageTag.java
@@ -1,0 +1,11 @@
+package org.dukecon.server.gui.tag;
+
+import com.tngtech.jgiven.annotation.IsTag;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@IsTag(name = "Page: Start")
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StartPageTag {
+}

--- a/impl/src/test/java/org/dukecon/server/util/arquillian/ContextExtension.java
+++ b/impl/src/test/java/org/dukecon/server/util/arquillian/ContextExtension.java
@@ -1,0 +1,13 @@
+package org.dukecon.server.util.arquillian;
+
+
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+public class ContextExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(ResourceProvider.class, ContextProvider.class);
+    }
+}

--- a/impl/src/test/java/org/dukecon/server/util/arquillian/ContextProvider.java
+++ b/impl/src/test/java/org/dukecon/server/util/arquillian/ContextProvider.java
@@ -1,0 +1,26 @@
+package org.dukecon.server.util.arquillian;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+import java.net.URL;
+
+public class ContextProvider implements ResourceProvider {
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return URL.class.isAssignableFrom(type);
+    }
+
+    private static ThreadLocal<URL> url = new ThreadLocal<>();
+
+    public static void setUrl(URL url) {
+        ContextProvider.url.set(url);
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        return url.get();
+    }
+}

--- a/impl/src/test/java/org/dukecon/server/util/arquillian/ContextRule.java
+++ b/impl/src/test/java/org/dukecon/server/util/arquillian/ContextRule.java
@@ -1,0 +1,28 @@
+package org.dukecon.server.util.arquillian;
+
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+public class ContextRule implements MethodRule {
+    private ContextUrl contextUrl;
+
+    public ContextRule(ContextUrl contextUrl) {
+        this.contextUrl = contextUrl;
+    }
+
+    @Override
+    public Statement apply(Statement base, FrameworkMethod method, Object target) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                ContextProvider.setUrl(contextUrl.url());
+                try {
+                    base.evaluate();
+                } finally {
+                    ContextProvider.setUrl(null);
+                }
+            }
+        };
+    }
+}

--- a/impl/src/test/java/org/dukecon/server/util/arquillian/ContextUrl.java
+++ b/impl/src/test/java/org/dukecon/server/util/arquillian/ContextUrl.java
@@ -1,0 +1,8 @@
+package org.dukecon.server.util.arquillian;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public interface ContextUrl {
+    URL url() throws MalformedURLException;
+}

--- a/impl/src/test/java/org/dukecon/server/util/arquillian/package-info.java
+++ b/impl/src/test/java/org/dukecon/server/util/arquillian/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Classes to provide the URL context to Arquillian. ContextExtension is registered in
+ * META-INF.services.
+ */
+package org.dukecon.server.util.arquillian;

--- a/impl/src/test/java/org/jboss/arquillian/junit/ArquillianClassRule.java
+++ b/impl/src/test/java/org/jboss/arquillian/junit/ArquillianClassRule.java
@@ -1,0 +1,68 @@
+package org.jboss.arquillian.junit;
+
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptorBuilder;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class ArquillianClassRule implements TestRule {
+
+    private TestRunnerAdaptor adaptor;
+
+    public Statement apply(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                State.runnerStarted();
+                // first time we're being initialized
+                if (!State.hasTestAdaptor()) {
+                    // no, initialization has been attempted before and failed, refuse
+                    // to do anything else
+                    if (State.hasInitializationException()) {
+                        // failed on suite level, ignore children
+                        // notifier.fireTestIgnored(getDescription());
+                        throw new RuntimeException(
+                                "Arquillian has previously been attempted initialized, but failed. See cause for previous exception",
+                                State.getInitializationException());
+                    } else {
+                        try {
+                            // ARQ-1742 If exceptions happen during boot
+                            TestRunnerAdaptor adaptor = TestRunnerAdaptorBuilder
+                                    .build();
+                            // don't set it if beforeSuite fails
+                            adaptor.beforeSuite();
+                            State.testAdaptor(adaptor);
+                        } catch (Exception e) {
+                            // caught exception during BeforeSuite, mark this as failed
+                            State.caughtInitializationException(e);
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+
+                // initialization ok, run children
+                if (State.hasTestAdaptor()) {
+                    adaptor = State.getTestAdaptor();
+                }
+
+                adaptor.beforeClass(description.getTestClass(),
+                        LifecycleMethodExecutor.NO_OP);
+                try {
+                    base.evaluate();
+                } finally {
+                    adaptor.afterClass(description.getTestClass(),
+                            LifecycleMethodExecutor.NO_OP);
+                    State.runnerFinished();
+                    if (State.isLastRunner()) {
+                        adaptor.afterSuite();
+                        adaptor.shutdown();
+                        State.clean();
+                    }
+                }
+            }
+        };
+    }
+
+}

--- a/impl/src/test/java/org/jboss/arquillian/junit/ArquillianRule.java
+++ b/impl/src/test/java/org/jboss/arquillian/junit/ArquillianRule.java
@@ -1,0 +1,63 @@
+package org.jboss.arquillian.junit;
+
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestResult.Status;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+import java.lang.reflect.Method;
+
+public class ArquillianRule implements MethodRule {
+
+    private TestRunnerAdaptor adaptor;
+
+    public ArquillianRule() {
+        if (State.hasTestAdaptor()) {
+            adaptor = State.getTestAdaptor();
+        } else {
+            throw new IllegalStateException("arquillian not initialized");
+        }
+    }
+
+    public Statement apply(final Statement base, final FrameworkMethod method,
+                           final Object target) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                adaptor.before(target, method.getMethod(),
+                        LifecycleMethodExecutor.NO_OP);
+                try {
+                    TestResult result = adaptor.test(new TestMethodExecutor() {
+                        public void invoke(Object... parameters)
+                                throws Throwable {
+                            base.evaluate();
+                        }
+
+                        public Method getMethod() {
+                            return method.getMethod();
+                        }
+
+                        public Object getInstance() {
+                            return target;
+                        }
+                    });
+                    if (result.getThrowable() != null) {
+                        throw result.getThrowable();
+                    }
+                    if (result.getStatus() != Status.PASSED) {
+                        throw new RuntimeException("problem: " + result);
+                    }
+
+                } finally {
+                    adaptor.after(target, method.getMethod(),
+                            LifecycleMethodExecutor.NO_OP);
+                }
+            }
+        };
+    }
+
+}

--- a/impl/src/test/java/org/jboss/arquillian/junit/package-info.java
+++ b/impl/src/test/java/org/jboss/arquillian/junit/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package contains Arquillian's JUnit runner reworked as two JUnit rules.
+ * This way they can be combined with the SpringJUnit4ClassRunner.
+ */
+package org.jboss.arquillian.junit;

--- a/impl/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/impl/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.dukecon.server.util.arquillian.ContextExtension

--- a/impl/src/test/resources/arquillian-headless.xml
+++ b/impl/src/test/resources/arquillian-headless.xml
@@ -1,0 +1,20 @@
+<arquillian xmlns="http://jboss.com/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <extension qualifier="webdriver">
+        <property name="browser">phantomjs</property>
+    </extension>
+
+    <!--
+    use the following for a local setup with a running firefox
+    -->
+    <!--
+    <extension qualifier="webdriver">
+        <property name="remoteReusable">true</property>
+        <property name="remoteAddress">http://localhost:4444/wd/hub/</property>
+        <property name="browser">firefox</property>
+    </extension>
+    -->
+
+</arquillian>

--- a/impl/src/test/resources/arquillian.xml
+++ b/impl/src/test/resources/arquillian.xml
@@ -1,0 +1,11 @@
+<arquillian xmlns="http://jboss.com/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <extension qualifier="webdriver">
+        <property name="remoteReusable">true</property>
+        <property name="remoteAddress">http://localhost:4444/wd/hub/</property>
+        <property name="browser">firefox</property>
+    </extension>
+
+</arquillian>


### PR DESCRIPTION
Hello Gerd aka @ascheman 

we discussed if GUI testing could be applied to the Dukecon at the most recent JUG Frankfurt meeting. 

In this pull request I've prepared a setup with [Arquillian](http://arquillian.org/) and [JGiven](http://jgiven.org/) as part of the `impl` project. 

I like JGiven as it allows you to write expressive BDD Java code that is fully refactorable in your IDE. 

```
@Test
public void should_show_details_page() throws InterruptedException {
    given().start_page_opened_in_browser();
    when().click_on_first_talk();
    then().talk_details_are_visible()
            .and().talk_abstract_is_visible();
}
```

This translates to Gherkin text output on the command line:

```
Scenario: should show details page

Given start page opened in browser
 When click on first talk
 Then talk details are visible
  And talk abstract is visible
```

In the background there is also a JSON file with all the contents that can be transformed by `mvn jgiven:report` to a nice HTML report. It even appeals to business users (the small paperclips include screen shots of the pages). 

![jgiven_dukecon](https://cloud.githubusercontent.com/assets/3957921/11510831/e9379b7c-9865-11e5-9d5e-c791923996e0.PNG)

Please have a look at GUITESTING.adoc for more information. The tests can be run as unit tests locally in the IDE (standard setup is to use a locally running firefox) or via phantomJS on travis.

This is just a basis for discussions. Please discuss and let me know what you think. I know that there is overlap with Spock that is already part of the project. Let's discuss and see where we end up.

Best regards,
Alexander aka @ahus1
