### PR TITLE
Upgraded to jQAssistant 1.7.0-MS3 and optimized configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <jersey-server.version>2.27</jersey-server.version>
         <jgiven-core.version>0.17.0</jgiven-core.version>
         <jgravatar.version>1.1</jgravatar.version>
-        <jqassistant-maven-plugin.version>1.6.0</jqassistant-maven-plugin.version>
+        <jqassistant-maven-plugin.version>1.7.0-MS3</jqassistant-maven-plugin.version>
         <jqassistant.plugin.git.version>1.6.1</jqassistant.plugin.git.version>
         <junit.version>4.12</junit.version>
         <keycloak.version>4.8.3.Final</keycloak.version>
@@ -944,38 +944,10 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.commonjava.maven.plugins</groupId>
-                        <artifactId>directory-maven-plugin</artifactId>
-                        <version>${directory-maven-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <phase>validate</phase>
-                                <goals>
-                                    <goal>highest-basedir</goal>
-                                </goals>
-                                <configuration>
-                                    <property>root.basedir</property>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>com.buschmais.jqassistant</groupId>
                         <artifactId>jqassistant-maven-plugin</artifactId>
                         <version>${jqassistant-maven-plugin.version}</version>
                         <extensions>true</extensions>
-                        <configuration>
-                            <failOnSeverity>MAJOR</failOnSeverity>
-                            <storeLifecycle>MODULE</storeLifecycle>
-                            <storeDirectory>${root.basedir}/target/jqassistant/store</storeDirectory>
-                        </configuration>
-                        <dependencies>
-                            <dependency>
-                                <groupId>de.kontext-e.jqassistant.plugin</groupId>
-                                <artifactId>jqassistant.plugin.git</artifactId>
-                                <version>${jqassistant.plugin.git.version}</version>
-                            </dependency>
-                        </dependencies>
                         <executions>
                             <execution>
                                 <goals>
@@ -984,6 +956,22 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <failOnSeverity>MAJOR</failOnSeverity>
+							<useExecutionRootAsProjectRoot>true</useExecutionRootAsProjectRoot>
+                            <scanIncludes>
+                                <scanInclude>
+                                    <path>${project.basedir}/.git</path>
+                                </scanInclude>
+                            </scanIncludes>
+						</configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>de.kontext-e.jqassistant.plugin</groupId>
+                                <artifactId>jqassistant.plugin.git</artifactId>
+                                <version>${jqassistant.plugin.git.version}</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This PR contains a version upgrade to jQAssistant 1.7.0-MS3 as well as configuration changes that resolve some observed issues:

- The database directory cannot be re-used during a build
- The embedded jQAssistant Neo4j server cannot be started due to ClassNotFoundExceptions.

Note that on startup of the server currently a stacktrace is logged. This is caused by a used library but will be resolved with the next official release of jQA.